### PR TITLE
Filters out unnamed routes

### DIFF
--- a/src/Routes/Collection.php
+++ b/src/Routes/Collection.php
@@ -32,7 +32,7 @@ class Collection extends BaseCollection
     {
         $data = parent::getRouteInformation($route, $filter, $namespace);
 
-        if (!$data) {
+        if (!$data || empty($data['name'])) {
             return null;
         }
 


### PR DESCRIPTION
Unnamed routes were being added to the route manifest, which is pointless as they cannot be selected without a name explicitly set.