### PR TITLE
Drop Illuminate/Support requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     ],
     "license" : "MIT",
     "require" : {
-        "illuminate/support" : "^5.4|^6.0",
         "lord/laroute" : "^2.4"
     },
     "autoload" : {


### PR DESCRIPTION
Pretty sure you don't need to depend on `illuminate/support` as none of the code in the package uses it directly and the dependency is enforce by the parent `lord/laroute` package 👍 